### PR TITLE
[FIX] Fix the test case and opt

### DIFF
--- a/include/data_structures/pool.hpp
+++ b/include/data_structures/pool.hpp
@@ -72,6 +72,8 @@ public:
         //      we would always move, even when the caller passed an lvalue—often the wrong choice.
         //   * With  TType(std::forward<TArgs>(args)...) the compiler
         //     picks copy or move for each argument as appropriate.
+
+        // BUG: here the TType constructor will also been called and trigger the assignement
         *obj = TType(std::forward<TArgs>(args)...);
         return Object<TType>(obj, this);
     }

--- a/include/data_structures/pool.hpp
+++ b/include/data_structures/pool.hpp
@@ -56,6 +56,16 @@ public:
     }
     ~Pool() = default;
 
+    void resize(const size_t& numberOfObjectStored) {
+        _storage.clear();
+        _available.clear();
+
+        for (size_t i = 0; i < numberOfObjectStored; i++) {
+            _storage.emplace_back(std::make_unique<TType>());
+            _available.push_back(_storage.back().get());
+        }
+    }
+
     template <typename... TArgs>
     Object<TType> acquire(TArgs&&... args) {
         if (_available.empty())
@@ -73,25 +83,18 @@ public:
         //   * With  TType(std::forward<TArgs>(args)...) the compiler
         //     picks copy or move for each argument as appropriate.
 
-        // BUG: here the TType constructor will also been called and trigger the assignement
+        // the TType constructor will be called but not allocate the memory again
         *obj = TType(std::forward<TArgs>(args)...);
         return Object<TType>(obj, this);
     }
 
-    void resize(const size_t& numberOfObjectStored) {
-        _storage.clear();
-        _available.clear();
-
-        for (size_t i = 0; i < numberOfObjectStored; i++) {
-            auto obj = std::make_unique<TType>();
-            // push the ptr of obj only
-            _available.push_back(obj.get());
-            _storage.push_back(std::move(obj));
-        }
-    }
-
     void release(TType* obj) {
-        _available.push_back(obj);
+        for (auto& ptr : _storage) {
+            if (ptr.get() == obj) {
+                _available.push_back(ptr.get());
+                return;
+            }
+        }
     }
 
 private:


### PR DESCRIPTION
So the major change is the way I test the pool.

I think here even I call the constructor every time in `acquire` but it should be fine bc it doesn't allocate memory for it.
```c++
// the TType constructor will be called but not allocate the memory again
*obj = TType(std::forward<TArgs>(args)...);
```

So I change the way in the test to count the `new` and `delete`. I called the acquire 3 times and release 3 times and new and delete didnt be triggered. The delete only be triggered when the pool destory.

```c++
struct Dummy {
    static inline size_t newCount  = 0;
    static inline size_t delCount  = 0;

    static void* operator new(std::size_t sz) {
        ++newCount;
        return ::operator new(sz);
    }
    static void operator delete(void* p) noexcept {
        ++delCount;
        ::operator delete(p);
    }

    int a{};
    std::string s;
};

TEST(PoolTest, NoExtraAllocationInAcquire) {
    Dummy::newCount = Dummy::delCount = 0;
    {
        Pool<Dummy> pool(3);
        EXPECT_EQ(Dummy::newCount, 3);

        auto h1 = pool.acquire(1, "x");
        auto h2 = pool.acquire(2, "y");
        auto h3 = pool.acquire(3, "z");

        pool.release(h1.operator->());
        pool.release(h2.operator->());
        pool.release(h3.operator->());
        EXPECT_EQ(Dummy::newCount, 3);
        EXPECT_EQ(Dummy::delCount, 0);

    }
    EXPECT_EQ(Dummy::delCount, 3);
}
```